### PR TITLE
Add missing N/A fallback on DIMM memory

### DIFF
--- a/netbox_agent/lshw.py
+++ b/netbox_agent/lshw.py
@@ -129,7 +129,7 @@ class LSHW():
             d["id"] = dimm.get("id")
             d["serial"] = dimm.get("serial", 'N/A')
             d["vendor"] = dimm.get("vendor", 'N/A')
-            d["product"] = dimm.get("product")
+            d["product"] = dimm.get("product", 'N/A')
             d["size"] = dimm.get("size", 0) / 2 ** 20 / 1024
 
             self.memories.append(d)


### PR DESCRIPTION
Fix

```
DEBUG:urllib3.connectionpool:https://netbox:443 "GET /api/dcim/manufacturers/?name=HP HTTP/1.1" 200 155
{'description': 'DIMM DDR3 Synchronous Registered (Buffered) 1333 MHz (0.8 ns)',
 'id': 'bank:0',
 'product': None,
 'serial': 'N/A',
 'size': 8.0,
 'slot': 'PROC  1 DIMM  1',
 'vendor': 'HP'}
DEBUG:urllib3.connectionpool:https://netbox:443 "POST /api/dcim/inventory-items/ HTTP/1.1" 400 43
Traceback (most recent call last):
  File "/usr/bin/netbox_agent", line 11, in <module>
    load_entry_point('netbox-agent==0.6.0', 'console_scripts', 'netbox_agent')()
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 44, in main
    return run(config)
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 39, in run
    server.netbox_create_or_update(config)
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/server.py", line 272, in netbox_create_or_update
    self.inventory.create_or_update()
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 447, in create_or_update
    self.do_netbox_memories()
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 441, in do_netbox_memories
    self.create_netbox_memory(memory)
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 414, in create_netbox_memory
    description=memory['description'],
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/pynetbox/core/endpoint.py", line 287, in create
    ).post(args[0] if args else kwargs)
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/pynetbox/core/query.py", line 381, in post
    return self._make_call(verb="post", data=data)
  File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/pynetbox/core/query.py", line 274, in _make_call
    raise RequestError(req)
pynetbox.core.query.RequestError: The request failed with code 400 Bad Request: {'part_id': ['This field may not be null.']}
```