### PR TITLE
Fix HP raid controller parsing

### DIFF
--- a/netbox_agent/raid/hp.py
+++ b/netbox_agent/raid/hp.py
@@ -60,7 +60,7 @@ def _get_dict(lines, start_index, indentation):
         if current_line_indentation == 0 and not product_name:
             i = i + 1
             continue
- 
+
         if current_line_indentation == indentation:
             current_item = current_line.lstrip(' ')
 


### PR DESCRIPTION
Some messages about the cache for example, with indentation level 0 break the parsing.
I ignore line indentation if indentation level and line dont match REGEXP_CONTROLLER_HP.

```bash

DC1|server-01:~# hpacucli ctrl all show detail

Smart Array P244br in Slot 0 (Embedded)
A cache backup failure has occurred. Please execute the "reenablecache" command
to enable the cache. Your controller may require a reboot after the operation
to complete the cache recovery process.

   Bus Interface: PCI
   Slot: 0
   Serial Number: PDZVU0VLM241FP
   Cache Serial Number: PDZVU0VLM241FP
   RAID 6 (ADG) Status: Enabled
   Controller Status: OK
   Hardware Revision: B
   Firmware Version: 7.00-0
   ...
```