### PR TITLE
Add openvpn TUN and TAP interfaces support, change type to Virtual and remove mac address

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -90,6 +90,12 @@ class Network(object):
                 bonding_slaves = open(
                     '/sys/class/net/{}/bonding/slaves'.format(interface)
                 ).read().split()
+
+            # Tun and TAP support
+            virtual = os.path.isfile(
+                '/sys/class/net/{}/tun_flags'.format(interface)
+            )
+
             nic = {
                 'name': interface,
                 'mac': mac if mac != '00:00:00:00:00:00' else None,
@@ -100,6 +106,7 @@ class Network(object):
                     ) for x in ip_addr
                 ] if ip_addr else None,  # FIXME: handle IPv6 addresses
                 'ethtool': Ethtool(interface).parse(),
+                'virtual': virtual,
                 'vlan': vlan,
                 'bonding': bonding,
                 'bonding_slaves': bonding_slaves,
@@ -159,6 +166,10 @@ class Network(object):
 
         if nic.get('bonding'):
             return self.dcim_choices['interface:type']['Link Aggregation Group (LAG)']
+
+        if nic.get('virtual') or nic.get('mac') is None:
+            return self.dcim_choices['interface:type']['Virtual']
+
         if nic.get('ethtool') is None:
             return self.dcim_choices['interface:type']['Other']
 
@@ -237,13 +248,20 @@ class Network(object):
             name=nic['name'], mac=nic['mac'], device=self.device.name))
 
         nb_vlan = None
-        interface = self.nb_net.interfaces.create(
-            name=nic['name'],
-            mac_address=nic['mac'],
-            type=type,
-            mgmt_only=mgmt,
+
+        params = {
+            'name': nic['name'],
+            'mac_address': nic['mac'],
+            'type': type,
+            'mgmt_only': mgmt,
             **self.custom_arg,
-        )
+        }
+
+        # Remove mac for virtual
+        if nic.get('virtual', False):
+            del params['mac_address']
+
+        interface = self.nb_net.interfaces.create(**params)
 
         if nic['vlan']:
             nb_vlan = self.get_or_create_vlan(nic['vlan'])

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -80,6 +80,10 @@ class Network(object):
                         ip_addr.pop(i)
 
             mac = open('/sys/class/net/{}/address'.format(interface), 'r').read().strip()
+            # Loopback lo
+            if mac == '00:00:00:00:00:00':
+                mac = None
+
             vlan = None
             if len(interface.split('.')) > 1:
                 vlan = int(interface.split('.')[1])
@@ -98,7 +102,7 @@ class Network(object):
 
             nic = {
                 'name': interface,
-                'mac': mac if mac != '00:00:00:00:00:00' else None,
+                'mac': mac,
                 'ip': [
                     '{}/{}'.format(
                         x['addr'],
@@ -167,7 +171,7 @@ class Network(object):
         if nic.get('bonding'):
             return self.dcim_choices['interface:type']['Link Aggregation Group (LAG)']
 
-        if nic.get('virtual') or nic.get('mac') is None:
+        if nic.get('virtual'):
             return self.dcim_choices['interface:type']['Virtual']
 
         if nic.get('ethtool') is None:
@@ -257,7 +261,7 @@ class Network(object):
             **self.custom_arg,
         }
 
-        # Remove mac for virtual
+        # Remove mac for virtual interface
         if nic.get('virtual', False):
             del params['mac_address']
 


### PR DESCRIPTION
Prevent crash due to unsupported mac format "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" for a physical interface.

```
tun0       Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  
          inet addr:10.10.0.2  P-t-P:10.10.0.1  Mask:255.255.255.255
          inet6 addr: fe80::909:ce5:bb8d:1c46/64 Scope:Link
          UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:13000  Metric:1
          RX packets:175558389 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1436009662 errors:0 dropped:122828 overruns:0 carrier:0
          collisions:0 txqueuelen:100 
          RX bytes:29344700802 (29.3 GB)  TX bytes:1330509519768 (1.3 TB)
```