### PR TITLE
small fix to add recognition of RHEV- Virtual machines

### DIFF
--- a/netbox_agent/virtualmachine.py
+++ b/netbox_agent/virtualmachine.py
@@ -16,6 +16,7 @@ def is_vm(dmi):
     if 'Hyper-V' in bios[0]['Version'] or \
        'Xen' in bios[0]['Version'] or \
        'Google Compute Engine' in system[0]['Product Name'] or \
+       'RHEV Hypervisor' in system[0]['Product Name'] or \
        'VirtualBox' in bios[0]['Version'] or \
        'VMware' in system[0]['Manufacturer']:
         return True


### PR DESCRIPTION
Just digging more into the code. Saw a small change that I could add. Tested and works.

```
# dmidecode 3.2
Getting SMBIOS data from sysfs.
SMBIOS 2.8 present.
17 structures occupying 1162 bytes.
Table at 0xBFFFFB70.

Handle 0x0000, DMI type 0, 24 bytes
BIOS Information
        Vendor: SeaBIOS
        Version: 1.9.1-5.el7_3.2
        Release Date: 04/01/2014
        Address: 0xE8000
        Runtime Size: 96 kB
        ROM Size: 64 kB
        Characteristics:
                BIOS characteristics not supported
                Targeted content distribution is supported
        BIOS Revision: 0.0

Handle 0x0100, DMI type 1, 27 bytes
System Information
        Manufacturer: Red Hat
        Product Name: RHEV Hypervisor
        Version: 7.3-1.1.el7
        Serial Number: e5226058-9c7e-45ca-a90a-2a721ab1e269
        UUID: 9a048ba4-e7e9-44d4-851e-0a6abd6aca20
        Wake-up Type: Power Switch
        SKU Number: Not Specified
        Family: Red Hat Enterprise Linux
```
