### PR TITLE
Adding the --netbox.ssl_verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ INFO:root:Creating Disk Samsung SSD 850 S2RBNX0K101698D
 netbox:
  url: 'http://netbox.internal.company.com'
  token: supersecrettoken
+ # uncomment to disable ssl verification
+ # ssl_verify: false
 
 # Network configuration
 network:

--- a/netbox_agent.yaml.example
+++ b/netbox_agent.yaml.example
@@ -1,6 +1,8 @@
 netbox:
  url: 'http://netbox.internal.company.com'
  token: supersecrettoken
+ # uncomment to disable ssl verification
+ # ssl_verify: false
 
 network:
   ignore_interfaces: "(dummy.*|docker.*)"

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -1,11 +1,10 @@
 import logging
 import sys
 
-import requests
-import urllib3
-
 import jsonargparse
 import pynetbox
+import requests
+import urllib3
 
 
 def get_config():

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -1,6 +1,7 @@
 import logging
-import requests
 import sys
+
+import requests
 import urllib3
 
 import jsonargparse

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -1,6 +1,6 @@
 import logging
-import sys
 import requests
+import sys
 import urllib3
 
 import jsonargparse

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -81,7 +81,7 @@ def get_netbox_instance():
     if config.netbox.url is None or config.netbox.token is None:
         logging.error('Netbox URL and token are mandatory')
         sys.exit(1)
-    
+
     nb = pynetbox.api(
         url=get_config().netbox.url,
         token=get_config().netbox.token,
@@ -93,6 +93,7 @@ def get_netbox_instance():
         nb.http_session = session
 
     return nb
+
 
 config = get_config()
 netbox_instance = get_netbox_instance()

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -32,6 +32,8 @@ def get_config():
     p.add_argument('--log_level', default='debug')
     p.add_argument('--netbox.url', help='Netbox URL')
     p.add_argument('--netbox.token', help='Netbox API Token')
+    p.add_argument('--netbox.ssl_verify', default=True, action='store_true',
+                   help='Disable SSL verification')
     p.add_argument('--virtual.enabled', action='store_true', help='Is a virtual machine or not')
     p.add_argument('--virtual.cluster_name', help='Cluster name of VM')
     p.add_argument('--hostname_cmd', default=None,
@@ -69,8 +71,6 @@ def get_config():
     p.add_argument('--network.lldp', help='Enable auto-cabling feature through LLDP infos')
     p.add_argument('--inventory', action='store_true',
                    help='Enable HW inventory (CPU, Memory, RAID Cards, Disks) feature')
-    p.add_argument('--no_ssl_verify', default=False, action='store_true',
-                   help='Disable SSL verification')
 
     options = p.parse_args()
     return options
@@ -86,7 +86,7 @@ def get_netbox_instance():
         url=get_config().netbox.url,
         token=get_config().netbox.token,
     )
-    if get_config().no_ssl_verify:
+    if get_config().netbox.ssl_verify is False:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         session = requests.Session()
         session.verify = False


### PR DESCRIPTION
Adding the --no_ssl_verify option to support Netbox connection with https and untrusted certificates

Usage example to allow connecting to netbox using self-signed certificates:
```
netbox_agent -c nbagent.yaml --register --no_ssl_verify
```
Usage exaample to allow connecting to netbox using https or ip:
```
netbox_agent -c nbagent.yaml --register
```