### PR TITLE
fix allocated_draw for inactive PSU

### DIFF
--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -117,10 +117,10 @@ class PowerSupply():
 
         for i, nb_psu in enumerate(nb_psus):
             nb_psu.allocated_draw = float(psu_cons[i]) * voltage
-            nb_psu.save()
             if nb_psu.allocated_draw < 1:
                 logging.info('PSU is not connected or in standby mode')
                 continue
+            nb_psu.save()
             logging.info('Updated power consumption for PSU {}: {}W'.format(
                 nb_psu.name,
                 nb_psu.allocated_draw,

--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -118,6 +118,9 @@ class PowerSupply():
         for i, nb_psu in enumerate(nb_psus):
             nb_psu.allocated_draw = float(psu_cons[i]) * voltage
             nb_psu.save()
+            if nb_psu.allocated_draw < 1:
+                logging.info('PSU is not connected or in standby mode')
+                continue
             logging.info('Updated power consumption for PSU {}: {}W'.format(
                 nb_psu.name,
                 nb_psu.allocated_draw,


### PR DESCRIPTION
If you have a setup when one of the power supplies is in passive mode, you may get an error from the API:

DEBUG:urllib3.connectionpool:https://netbox.domain.com:443 "PATCH /api/dcim/power-ports/16/ HTTP/1.1" 400 71
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/bin/netbox_agent", line 11, in <module>
    sys.exit(main())
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/netbox_agent/cli.py", line 44, in main
    return run(config)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/netbox_agent/cli.py", line 39, in run
    server.netbox_create_or_update(config)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/netbox_agent/server.py", line 301, in netbox_create_or_update
    self.power.report_power_consumption()
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/netbox_agent/power.py", line 123, in report_power_consumption
    nb_psu.save()
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pynetbox/core/response.py", line 391, in save
    if req.patch({i: serialized[i] for i in diff}):
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pynetbox/core/query.py", line 409, in patch
    return self._make_call(verb="patch", data=data)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pynetbox/core/query.py", line 274, in _make_call
    raise RequestError(req)
pynetbox.core.query.RequestError: The request failed with code 400 Bad Request: {'allocated_draw': ['Ensure this value is greater than or equal to 1.']}
