### PR TITLE
Fix a crash when missing rack id

### DIFF
--- a/netbox_agent/lldp.py
+++ b/netbox_agent/lldp.py
@@ -1,5 +1,7 @@
 import logging
 import subprocess
+import logging
+from netbox_agent.misc import is_tool
 
 from netbox_agent.misc import is_tool
 

--- a/netbox_agent/lldp.py
+++ b/netbox_agent/lldp.py
@@ -1,7 +1,5 @@
 import logging
 import subprocess
-import logging
-from netbox_agent.misc import is_tool
 
 from netbox_agent.misc import is_tool
 

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -66,7 +66,6 @@ class ServerBase():
 
     def update_netbox_location(self, server):
         dc = self.get_datacenter()
-        rack = self.get_rack()
         nb_rack = self.get_netbox_rack()
         nb_dc = self.get_netbox_datacenter()
 
@@ -80,8 +79,7 @@ class ServerBase():
             server.site = nb_dc.id
 
         if (
-            rack
-            and server.rack
+            server.rack
             and nb_rack
             and server.rack.id != nb_rack.id
         ):

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -81,7 +81,8 @@ class ServerBase():
 
         if (
             rack
-            and all(map(lambda x: x is not None and "id" in x, (nb_rack, server.rack)))
+            and server.rack
+            and nb_rack
             and server.rack.id != nb_rack.id
         ):
             logging.info('Rack location has changed from {} to {}, updating'.format(

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -79,7 +79,11 @@ class ServerBase():
             update = True
             server.site = nb_dc.id
 
-        if rack and all(map(lambda x: x is not None and "id" in x, (nb_rack, server.rack))) and server.rack.id != nb_rack.id:
+        if (
+            rack
+            and all(map(lambda x: x is not None and "id" in x, (nb_rack, server.rack)))
+            and server.rack.id != nb_rack.id
+        ):
             logging.info('Rack location has changed from {} to {}, updating'.format(
                 server.rack,
                 nb_rack,

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -79,7 +79,7 @@ class ServerBase():
             update = True
             server.site = nb_dc.id
 
-        if rack and server.rack and server.rack.id != nb_rack.id:
+        if rack and all(map(lambda x: x is not None and "id" in x, (nb_rack, server.rack))) and server.rack.id != nb_rack.id:
             logging.info('Rack location has changed from {} to {}, updating'.format(
                 server.rack,
                 nb_rack,


### PR DESCRIPTION
In some case, i miss id and this make crash the agent, i'm not sure its the ideal solution but this first the crash and I can register my device.
```
    Traceback (most recent call last):
      File "/usr/bin/netbox_agent", line 33, in <module>
        sys.exit(load_entry_point('netbox-agent==0.6.2', 'console_scripts', 'netbox_agent')())
      File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 44, in main
        return run(config)
      File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 39, in run
        server.netbox_create_or_update(config)
      File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/server.py", line 391, in netbox_create_or_update
        ret, server = self.update_netbox_location(server)
      File "/opt/venvs/netbox-agent/lib/python3.6/site-packages/netbox_agent/server.py", line 82, in update_netbox_location
        if rack and server.rack and server.rack.id != nb_rack.id:
    AttributeError: 'NoneType' object has no attribute 'id'
```
