### PR TITLE
Add support for Supermicro TwinPro devices

### DIFF
--- a/netbox_agent/vendors/supermicro.py
+++ b/netbox_agent/vendors/supermicro.py
@@ -27,6 +27,8 @@ class SupermicroHost(ServerBase):
         blade |= product_name.startswith('SBA')
         # Twin
         blade |= 'TR-' in product_name
+        # TwinPro
+        blade |= 'TP-' in product_name
         # BigTwin
         blade |= 'BT-' in product_name
         # Microcloud


### PR DESCRIPTION
This allows handling TwinPro Supermicro servers (e.g. `SYS-1028TP-DC1R`)