### PR TITLE
Remove an invalid character

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ network:
 #tenant:
 # driver: "file:/tmp/tenant"
 # regex: "(.*)"
-￼
+
 ## Enable virtual machine support 
 # virtual:
 #   # not mandatory, can be guessed


### PR DESCRIPTION
Invalid character that causes some errors to throw if you're copying and pasting the config