### PR TITLE
NVME inventory fix.

### DIFF
--- a/netbox_agent/lshw.py
+++ b/netbox_agent/lshw.py
@@ -104,7 +104,10 @@ class LSHW():
                         d['product'] = device["ModelNumber"]
                         d['serial'] = device["SerialNumber"]
                         d["version"] = device["Firmware"]
-                        d['size'] = device["UsedSize"]
+                        if "UsedSize" in device:
+                            d['size'] = device["UsedSize"]
+                        if "UsedBytes" in device:
+                            d['size'] = device["UsedBytes"]
                         d['description'] = "NVME Disk"
 
                         self.disks.append(d)


### PR DESCRIPTION
Hi @Solvik,

I hope you are well.

The inventory crash with default nvme-cli version 1.8.1 on Centos7.
This fix it.

Best regards,