### PR TITLE
So it would work on virtual also

### DIFF
--- a/netbox_agent/lshw.py
+++ b/netbox_agent/lshw.py
@@ -104,7 +104,10 @@ class LSHW():
                         d['product'] = device["ModelNumber"]
                         d['serial'] = device["SerialNumber"]
                         d["version"] = device["Firmware"]
-                        d['size'] = device["UsedSize"]
+                        if "UsedSize" in device:
+                            d['size'] = device["UsedSize"]
+                        if "UsedBytes" in device:
+                            d['size'] = device["UsedBytes"]
                         d['description'] = "NVME Disk"
 
                         self.disks.append(d)

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -214,7 +214,7 @@ class Network(object):
         lldp_vlan = self.lldp.get_switch_vlan(nic['name']) if config.network.lldp else None
         # For strange reason, we need to get the object from scratch
         # The object returned by pynetbox's save isn't always working (since pynetbox 6)
-        interface = nb.dcim.interfaces.get(id=interface.id)
+        interface = self.nb_net.interfaces.get(id=interface.id)
 
         # Handle the case were the local interface isn't an interface vlan as reported by Netbox
         # and that LLDP doesn't report a vlan-id

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -67,7 +67,6 @@ class ServerBase():
 
     def update_netbox_location(self, server):
         dc = self.get_datacenter()
-        rack = self.get_rack()
         nb_rack = self.get_netbox_rack()
         nb_dc = self.get_netbox_datacenter()
 
@@ -80,7 +79,11 @@ class ServerBase():
             update = True
             server.site = nb_dc.id
 
-        if rack and server.rack and server.rack.id != nb_rack.id:
+        if (
+            server.rack
+            and nb_rack
+            and server.rack.id != nb_rack.id
+        ):
             logging.info('Rack location has changed from {} to {}, updating'.format(
                 server.rack,
                 nb_rack,

--- a/netbox_agent/vendors/hp.py
+++ b/netbox_agent/vendors/hp.py
@@ -12,8 +12,10 @@ class HPHost(ServerBase):
 
     def is_blade(self):
         blade = self.product.startswith("ProLiant BL")
+
         blade |= self.product.startswith("ProLiant m") and \
             self.product.endswith("Server Cartridge")
+
         return blade
 
     def _find_rack_locator(self):


### PR DESCRIPTION
We found that this line caused when running it to fetch device interfaces and not virtual interface.
By using object reference it is now working