### PR TITLE
Added disks extended attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ netbox:
  token: supersecrettoken
  # uncomment to disable ssl verification
  # ssl_verify: false
+ # uncomment to use the system's CA certificates
+ # ssl_ca_certs_file: /etc/ssl/certs/ca-certificates.crt
 
 # Network configuration
 network:
-  # Regex to ignore interfaces 
+  # Regex to ignore interfaces
   ignore_interfaces: "(dummy.*|docker.*)"
   # Regex to ignore IP addresses
   ignore_ips: (127\.0\.0\..*)
@@ -119,7 +121,7 @@ network:
 # driver: "file:/tmp/tenant"
 # regex: "(.*)"
 
-## Enable virtual machine support 
+## Enable virtual machine support
 # virtual:
 #   # not mandatory, can be guessed
 #   enabled: True
@@ -145,7 +147,7 @@ rack_location:
 # driver: "file:/tmp/datacenter"
 # regex: "(.*)"
 
-# Enable local inventory reporting 
+# Enable local inventory reporting
 inventory: true
 ```
 
@@ -159,6 +161,36 @@ The `get_blade_slot` method return the name of the `Device Bay`.
 
 
 Certain vendors don't report the blade slot in `dmidecode`, so we can use the `slot_location` regex feature of the configuration file.
+
+Some blade servers can be equipped with additional hardware using expansion blades, next to the processing blade, such as GPU expansion, or drives bay expansion. By default, the hardware from the expnasion is associated with the blade server itself, but it's possible to register the expansion as its own device using the `--expansion-as-device` command line parameter, or by setting `expansion_as_device` to `true` in the configuration file.
+
+## Drives attributes processing
+
+It is possible to process drives extended attributes such as the drive's physical or logical identifier, logical drive RAID type, size, consistency and so on.
+
+Those attributes as set as `custom_fields` in Netbox, and need to be registered properly before being able to specify them during the inventory phase.
+
+As the custom fields have to be created prior being able to register the disks extended attributes, this feature is only activated using the `--process-virtual-drives` command line parameter, or by setting `process_virtual_drives` to `true` in the configuration file.
+
+The custom fields to create as `DCIM > inventory item` `Text` are described below.
+
+```
+NAME            LABEL                      DESCRIPTION
+mount_point     Mount point                Device mount point(s)
+pd_identifier   Physical disk identifier   Physical disk identifier in the RAID controller
+vd_array        Virtual drive array        Virtual drive array the disk is member of
+vd_consistency  Virtual drive consistency  Virtual disk array consistency
+vd_device       Virtual drive device       Virtual drive system device
+vd_raid_type    Virtual drive RAID         Virtual drive array RAID type
+vd_size         Virtual drive size         Virtual drive array size
+```
+
+In the current implementation, the disks attributes ore not updated: if a disk with the correct serial number is found, it's sufficient to consider it as up to date.
+
+To force the reprocessing of the disks extended attributes, the `--force-disk-refresh` command line option can be used: it removes all existing disks to before populating them with the correct parsing. Unless this option is specified, the extended attributes won't be modified unless a disk is replaced.
+
+It is possible to dump the physical/virtual disks map on the filesystem under the JSON notation to ease or automate disks management. The file path has to be provided using the `--dump-disks-map` command line parameter.
+
 
 ## Anycast IP
 
@@ -256,5 +288,5 @@ On a personal note, I use the docker image from [netbox-community/netbox-docker]
 # git clone https://github.com/netbox-community/netbox-docker
 # cd netbox-docker
 # docker-compose pull
-# docker-compose up 
+# docker-compose up
 ```

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -78,6 +78,13 @@ def get_config():
     p.add_argument('--network.lldp', help='Enable auto-cabling feature through LLDP infos')
     p.add_argument('--inventory', action='store_true',
                    help='Enable HW inventory (CPU, Memory, RAID Cards, Disks) feature')
+    p.add_argument('--process-virtual-drives', action='store_true',
+                   help='Process virtual drives information from RAID '
+                        'controllers to fill disk custom_fields')
+    p.add_argument('--force-disk-refresh', action='store_true',
+                   help='Forces disks detection reprocessing')
+    p.add_argument('--dump-disks-map',
+                   help='File path to dump physical/virtual disks map')
 
     options = p.parse_args()
     return options

--- a/netbox_agent/inventory.py
+++ b/netbox_agent/inventory.py
@@ -1,8 +1,3 @@
-import logging
-import re
-
-import pynetbox
-
 from netbox_agent.config import config
 from netbox_agent.config import netbox_instance as nb
 from netbox_agent.lshw import LSHW
@@ -10,6 +5,12 @@ from netbox_agent.misc import get_vendor, is_tool
 from netbox_agent.raid.hp import HPRaid
 from netbox_agent.raid.omreport import OmreportRaid
 from netbox_agent.raid.storcli import StorcliRaid
+import traceback
+import pynetbox
+import logging
+import json
+import re
+
 
 INVENTORY_TAG = {
     'cpu': {'name': 'hw:cpu', 'slug': 'hw-cpu'},
@@ -226,7 +227,7 @@ class Inventory():
 
     def get_raid_cards(self, filter_cards=False):
         raid_class = None
-        if self.server.manufacturer == 'Dell':
+        if self.server.manufacturer in ('Dell', 'Huawei'):
             if is_tool('omreport'):
                 raid_class = OmreportRaid
             if is_tool('storcli'):
@@ -302,52 +303,59 @@ class Inventory():
             if raid_card.get_serial_number() not in [x.serial for x in nb_raid_cards]:
                 self.create_netbox_raid_card(raid_card)
 
-    def is_virtual_disk(self, disk):
+    def is_virtual_disk(self, disk, raid_devices):
+        disk_type = disk.get('type')
         logicalname = disk.get('logicalname')
         description = disk.get('description')
         size = disk.get('size')
         product = disk.get('product')
-
+        if logicalname in raid_devices or disk_type is None:
+            return True
         non_raid_disks = [
             'MR9361-8i',
         ]
 
-        if size is None and logicalname is None or \
-           'virtual' in product.lower() or 'logical' in product.lower() or \
+        if logicalname in raid_devices or \
+           disk_type is None or \
            product in non_raid_disks or \
+           'virtual' in product.lower() or \
+           'logical' in product.lower() or \
+           'volume' in description.lower() or \
            description == 'SCSI Enclosure' or \
-           'volume' in description.lower():
+           (size is None and logicalname is None):
             return True
         return False
 
     def get_hw_disks(self):
         disks = []
 
+        for raid_card in self.get_raid_cards(filter_cards=True):
+            disks.extend(raid_card.get_physical_disks())
+
+        raid_devices = [
+            d.get('custom_fields', {}).get('vd_device')
+            for d in disks
+            if d.get('custom_fields', {}).get('vd_device')
+        ]
+
         for disk in self.lshw.get_hw_linux("storage"):
-            if self.is_virtual_disk(disk):
+            if self.is_virtual_disk(disk, raid_devices):
                 continue
-
-            logicalname = disk.get('logicalname')
-            description = disk.get('description')
-            size = disk.get('size', 0)
-            product = disk.get('product')
-            serial = disk.get('serial')
-
-            d = {}
-            d["name"] = ""
-            d['Size'] = '{} GB'.format(int(size / 1024 / 1024 / 1024))
-            d['logicalname'] = logicalname
-            d['description'] = description
-            d['SN'] = serial
-            d['Model'] = product
+            size =int(disk.get('size', 0)) / 1073741824
+            d = {
+                "name": "",
+                'Size': '{} GB'.format(size),
+                'logicalname': disk.get('logicalname'),
+                'description': disk.get('description'),
+                'SN': disk.get('serial'),
+                'Model': disk.get('product'),
+                'Type': disk.get('type'),
+            }
             if disk.get('vendor'):
                 d['Vendor'] = disk['vendor']
             else:
                 d['Vendor'] = get_vendor(disk['product'])
             disks.append(d)
-
-        for raid_card in self.get_raid_cards(filter_cards=True):
-            disks += raid_card.get_physical_disks()
 
         # remove duplicate serials
         seen = set()
@@ -361,53 +369,79 @@ class Inventory():
 
         logicalname = disk.get('logicalname')
         desc = disk.get('description')
-        # nonraid disk
-        if logicalname and desc:
-            if type(logicalname) is list:
-                logicalname = logicalname[0]
-            name = '{} - {} ({})'.format(
-                desc,
-                logicalname,
-                disk.get('Size', 0))
-            description = 'Device {}'.format(disk.get('logicalname', 'Unknown'))
-        else:
-            name = '{} ({})'.format(disk['Model'], disk['Size'])
-            description = '{}'.format(disk['Type'])
+        name = '{} ({})'.format(disk['Model'], disk['Size'])
+        description = disk['Type']
 
-        _ = nb.dcim.inventory_items.create(
-            device=self.device_id,
-            discovered=True,
-            tags=[{'name': INVENTORY_TAG['disk']['name']}],
-            name=name,
-            serial=disk['SN'],
-            part_id=disk['Model'],
-            description=description,
-            manufacturer=manufacturer.id if manufacturer else None
-        )
+        parms = {
+            'device': self.device_id,
+            'discovered': True,
+            'tags': [{'name': INVENTORY_TAG['disk']['name']}],
+            'name': name,
+            'serial': disk['SN'],
+            'part_id': disk['Model'],
+            'description': description,
+            'manufacturer': getattr(manufacturer, "id", None),
+        }
+        if config.process_virtual_drives:
+            parms['custom_fields'] = disk.get("custom_fields", {})
+
+        _ = nb.dcim.inventory_items.create(**parms)
 
         logging.info('Creating Disk {model} {serial}'.format(
             model=disk['Model'],
             serial=disk['SN'],
         ))
 
+    def dump_disks_map(self, disks):
+        disk_map = [d['custom_fields'] for d in disks if 'custom_fields' in d]
+        if config.dump_disks_map == "-":
+            f = sys.stdout
+        else:
+            f = open(config.dump_disks_map, "w")
+        f.write(
+            json.dumps(
+                disk_map,
+                separators=(',', ':'),
+                indent=4,
+                sort_keys=True
+            )
+        )
+        if config.dump_disks_map != "-":
+            f.close()
+
     def do_netbox_disks(self):
         nb_disks = self.get_netbox_inventory(
             device_id=self.device_id,
-            tag=INVENTORY_TAG['disk']['slug'])
+            tag=INVENTORY_TAG['disk']['slug']
+        )
         disks = self.get_hw_disks()
+        if config.dump_disks_map:
+            try:
+                self.dump_disks_map(disks)
+            except Exception as e:
+                logging.error("Failed to dump disks map: {}".format(e))
+                logging.debug(traceback.format_exc())
+        disk_serials = [d['SN'] for d in disks if 'SN' in d]
 
         # delete disks that are in netbox but not locally
         # use the serial_number has the comparison element
         for nb_disk in nb_disks:
-            if nb_disk.serial not in [x['SN'] for x in disks if x.get('SN')]:
+            if nb_disk.serial not in disk_serials or \
+                    config.force_disk_refresh:
                 logging.info('Deleting unknown locally Disk {serial}'.format(
                     serial=nb_disk.serial,
                 ))
                 nb_disk.delete()
 
+        if config.force_disk_refresh:
+            nb_disks = self.get_netbox_inventory(
+                device_id=self.device_id,
+                tag=INVENTORY_TAG['disk']['slug']
+            )
+
         # create disks that are not in netbox
         for disk in disks:
-            if disk.get('SN') not in [x.serial for x in nb_disks]:
+            if disk.get('SN') not in [d.serial for d in nb_disks]:
                 self.create_netbox_disk(disk)
 
     def create_netbox_memory(self, memory):

--- a/netbox_agent/misc.py
+++ b/netbox_agent/misc.py
@@ -1,10 +1,9 @@
-import socket
-import subprocess
-from shutil import which
-
-from slugify import slugify
-
 from netbox_agent.config import netbox_instance as nb
+from slugify import slugify
+from shutil import which
+import subprocess
+import socket
+import re
 
 
 def is_tool(name):
@@ -74,3 +73,19 @@ def create_netbox_tags(tags):
             )
         ret.append(nb_tag)
     return ret
+
+
+def get_mount_points():
+    mount_points = {}
+    output = subprocess.getoutput('mount')
+    for r in output.split("\n"):
+        if not r.startswith("/dev/"):
+            continue
+        mount_info = r.split()
+        device = mount_info[0]
+        device = re.sub(r'\d+$', '', device)
+        mp = mount_info[2]
+        mount_points.setdefault(device, []).append(mp)
+    return mount_points
+
+

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -325,7 +325,7 @@ class Network(object):
         netbox_ips = nb.ipam.ip_addresses.filter(
             address=ip,
         )
-        if not len(netbox_ips):
+        if not netbox_ips:
             logging.info('Create new IP {ip} on {interface}'.format(
                 ip=ip, interface=interface))
             query_params = {
@@ -340,7 +340,7 @@ class Network(object):
             )
             return netbox_ip
 
-        netbox_ip = next(netbox_ips)
+        netbox_ip = list(netbox_ips)[0]
         # If IP exists in anycast
         if netbox_ip.role and netbox_ip.role.label == 'Anycast':
             logging.debug('IP {} is Anycast..'.format(ip))

--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -115,7 +115,7 @@ class PowerSupply():
             voltage = [p['voltage'] for p in pwr_feeds]
         else:
             logging.info('Could not find power feeds for Rack, defaulting value to 230')
-            voltage = [230 for _ in nb_psu]
+            voltage = [230 for _ in nb_psus]
 
         for i, nb_psu in enumerate(nb_psus):
             nb_psu.allocated_draw = int(float(psu_cons[i]) * voltage[i])

--- a/netbox_agent/raid/storcli.py
+++ b/netbox_agent/raid/storcli.py
@@ -1,8 +1,31 @@
-import json
-import subprocess
-
-from netbox_agent.misc import get_vendor
 from netbox_agent.raid.base import Raid, RaidController
+from netbox_agent.misc import get_vendor, get_mount_points
+from netbox_agent.config import config
+import subprocess
+import logging
+import json
+import re
+import os
+
+
+def storecli(sub_command):
+    command = 'storcli {} J'.format(sub_command)
+    output = subprocess.getoutput(command)
+    data = json.loads(output)
+    controllers = dict([
+        (
+            c['Command Status']['Controller'],
+            c['Response Data']
+        ) for c in data['Controllers']
+        if c['Command Status']['Status'] == 'Success'
+    ])
+    if not controllers:
+        logging.error(
+            "Failed to execute command '{}'. "
+            "Ignoring data.".format(command)
+        )
+        return {}
+    return controllers
 
 
 class StorcliController(RaidController):
@@ -22,52 +45,101 @@ class StorcliController(RaidController):
     def get_firmware_version(self):
         return self.data['FW Package Build']
 
-    def get_physical_disks(self):
-        ret = []
-        output = subprocess.getoutput(
-            'storcli /c{}/eall/sall show all J'.format(self.controller_index)
-        )
-        drive_infos = json.loads(output)['Controllers'][self.controller_index]['Response Data']
+    def _get_physical_disks(self):
+        pds = {}
+        cmd = '/c{}/eall/sall show all'.format(self.controller_index)
+        controllers = storecli(cmd)
+        pd_info = controllers[self.controller_index]
+        pd_re = re.compile(r'^Drive (/c\d+/e\d+/s\d+)$')
 
-        for physical_drive in self.data['PD LIST']:
-            enclosure = physical_drive.get('EID:Slt').split(':')[0]
-            slot = physical_drive.get('EID:Slt').split(':')[1]
-            size = physical_drive.get('Size').strip()
-            media_type = physical_drive.get('Med').strip()
-            drive_identifier = 'Drive /c{}/e{}/s{}'.format(
-                str(self.controller_index), str(enclosure), str(slot)
-            )
-            drive_attr = drive_infos['{} - Detailed Information'.format(drive_identifier)][
-                '{} Device attributes'.format(drive_identifier)]
-            model = drive_attr.get('Model Number', '').strip()
-            ret.append({
+        for section, attrs in pd_info.items():
+            reg = pd_re.search(section)
+            if reg is None:
+                continue
+            pd_name = reg.group(1)
+            pd_attr = attrs[0]
+            pd_identifier = pd_attr['EID:Slt']
+            size = pd_attr.get('Size', '').strip()
+            media_type = pd_attr.get('Med', '').strip()
+            pd_details = pd_info['{} - Detailed Information'.format(section)]
+            pd_dev_attr = pd_details['{} Device attributes'.format(section)]
+            model = pd_dev_attr.get('Model Number', '').strip()
+            pd = {
                 'Model': model,
                 'Vendor': get_vendor(model),
-                'SN': drive_attr.get('SN', '').strip(),
+                'SN': pd_dev_attr.get('SN', '').strip(),
                 'Size': size,
                 'Type': media_type,
                 '_src': self.__class__.__name__,
-            })
-        return ret
+            }
+            if config.process_virtual_drives:
+                pd.setdefault('custom_fields', {})['pd_identifier'] = pd_name
+            pds[pd_identifier] = pd
+        return pds
+
+    def _get_virtual_drives_map(self):
+        vds = {}
+        cmd = '/c{}/vall show all'.format(self.controller_index)
+        controllers = storecli(cmd)
+        vd_info = controllers[self.controller_index]
+        mount_points = get_mount_points()
+
+        for vd_identifier, vd_attrs in vd_info.items():
+            if not vd_identifier.startswith("/c{}/v".format(self.controller_index)):
+                continue
+            volume = vd_identifier.split("/")[-1].lstrip("v")
+            vd_attr = vd_attrs[0]
+            vd_pd_identifier = 'PDs for VD {}'.format(volume)
+            vd_pds = vd_info[vd_pd_identifier]
+            vd_prop_identifier = 'VD{} Properties'.format(volume)
+            vd_properties = vd_info[vd_prop_identifier]
+            for pd in vd_pds:
+                pd_identifier = pd["EID:Slt"]
+                wwn = vd_properties["SCSI NAA Id"]
+                wwn_path = "/dev/disk/by-id/wwn-0x{}".format(wwn)
+                device = os.path.realpath(wwn_path)
+                mp = mount_points.get(device, "n/a")
+                vds[pd_identifier] = {
+                    "vd_array": vd_identifier,
+                    "vd_size": vd_attr["Size"],
+                    "vd_consistency": vd_attr["Consist"],
+                    "vd_raid_type": vd_attr["TYPE"],
+                    "vd_device": device,
+                    "mount_point": ", ".join(sorted(mp))
+                }
+        return vds
+
+    def get_physical_disks(self):
+        # Parses physical disks information
+        pds = self._get_physical_disks()
+
+        # Parses virtual drives information and maps them to physical disks
+        vds = self._get_virtual_drives_map()
+        for pd_identifier, vd in vds.items():
+            if pd_identifier not in pds:
+                logging.error(
+                    "Physical drive {} listed in virtual drive {} not "
+                    "found in drives list".format(
+                      pd_identifier, vd["vd_array"]
+                    )
+                )
+                continue
+            pds[pd_identifier].setdefault("custom_fields", {}).update(vd)
+
+        return list(pds.values())
 
 
 class StorcliRaid(Raid):
     def __init__(self):
-        self.output = subprocess.getoutput('storcli /call show J')
-        self.data = json.loads(self.output)
         self.controllers = []
-
-        if len([
-                x for x in self.data['Controllers']
-                if x['Command Status']['Status'] == 'Success'
-        ]) > 0:
-            for controller in self.data['Controllers']:
-                self.controllers.append(
-                    StorcliController(
-                        controller['Command Status']['Controller'],
-                        controller['Response Data']
-                    )
+        controllers =  storecli('/call show')
+        for controller_id, controller_data in controllers.items():
+            self.controllers.append(
+                StorcliController(
+                    controller_id,
+                    controller_data
                 )
+            )
 
     def get_controllers(self):
         return self.controllers

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -1,9 +1,3 @@
-import logging
-import socket
-import subprocess
-import sys
-from pprint import pprint
-
 import netbox_agent.dmidecode as dmidecode
 from netbox_agent.config import config
 from netbox_agent.config import netbox_instance as nb
@@ -12,6 +6,11 @@ from netbox_agent.location import Datacenter, Rack, Tenant
 from netbox_agent.misc import create_netbox_tags, get_device_role, get_device_type
 from netbox_agent.network import ServerNetwork
 from netbox_agent.power import PowerSupply
+from pprint import pprint
+import subprocess
+import logging
+import socket
+import sys
 
 
 class ServerBase():
@@ -491,5 +490,17 @@ class ServerBase():
     def own_expansion_slot(self):
         """
         Indicates if the device hosts an expansion card
+        """
+        return False
+
+    def own_gpu_expansion_slot(self):
+        """
+        Indicates if the device hosts a GPU expansion card
+        """
+        return False
+
+    def own_drive_expansion_slot(self):
+        """
+        Indicates if the device hosts a drive expansion bay
         """
         return False

--- a/netbox_agent/vendors/generic.py
+++ b/netbox_agent/vendors/generic.py
@@ -8,7 +8,7 @@ class GenericHost(ServerBase):
         self.manufacturer = dmidecode.get_by_type(self.dmi, 'Baseboard')[0].get('Manufacturer')
 
     def is_blade(self):
-        return None
+        return False
 
     def get_blade_slot(self):
         return None


### PR DESCRIPTION
This patch brings some of the physical and virtual drive attributes as `custom_fields` to the disks inventory.

The goal is to have this information present to ease disks maintenance when a drive becomes unavailable and its attributes can't be read anymore from the RAID controller.

It also helps to standardize the extended disk attributes across the different manufacturers.

As the disk physical identifers were not available under the correct format (hexadecimal format using the `xml` output as opposed as `X:Y:Z` format using the default `list` format), the command line parser has been refactored to read the `list` format, rather than `xml` one in the `omreport` raid controller parser.

As the custom fields have to be created prior being able to register the disks extended attributes, this feature is only activated using the `--process-virtual-drives` command line parameter, or by setting `process_virtual_drives` to `true` in the configuration file.

The custom fields to create as `DCIM > inventory item` `Text` are described below.

    NAME            LABEL                      DESCRIPTION
    mount_point     Mount point                Device mount point(s)
    pd_identifier   Physical disk identifier   Physical disk identifier in the RAID controller
    vd_array        Virtual drive array        Virtual drive array the disk is member of
    vd_consistency  Virtual drive consistency  Virtual disk array consistency
    vd_device       Virtual drive device       Virtual drive system device
    vd_raid_type    Virtual drive RAID         Virtual drive array RAID type
    vd_size         Virtual drive size         Virtual drive array size

In the current implementation, the disks attributes ore not updated: if a disk with the correct serial number is found, it's sufficient to consider it as up to date.

To force the reprocessing of the disks extended attributes, the `--force-disk-refresh` command line option can be used: it removes all existing disks to before populating them with the correct parsing. Unless this option is specified, the extended attributes won't be modified unless a disk is replaced.

It is possible to dump the physical/virtual disks map on the filesystem under the JSON notation to ease or automate disks management. The file path has to be provided using the `--dump-disks-map` command line parameter.