### PR TITLE
Fixed virtual network cards creation

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -261,7 +261,7 @@ class Network(object):
 
     def create_netbox_nic(self, nic, mgmt=False):
         # TODO: add Optic Vendor, PN and Serial
-        type = self.get_netbox_type_for_nic(nic)
+        nic_type = self.get_netbox_type_for_nic(nic)
         logging.info('Creating NIC {name} ({mac}) on {device}'.format(
             name=nic['name'], mac=nic['mac'], device=self.device.name))
 
@@ -270,11 +270,10 @@ class Network(object):
         params = dict(self.custom_arg)
         params.update({
             'name': nic['name'],
-            'type': type,
+            'type': nic_type,
             'mgmt_only': mgmt,
         })
-
-        if not nic.get('virtual', False):
+        if nic['mac']:
             params['mac_address'] = nic['mac']
 
         interface = self.nb_net.interfaces.create(**params)


### PR DESCRIPTION
This patch fixes a mismatch between the way network interfaces are looked for from network cards, and the way they are created:

- If a network card has a NAC address, it used in the search criteria to
  find the network interface
- When creating virtual interfaces, the MAC address is not specified in
  the creation parameters

This raises an exception when a virtual card has a MAC address:

- The virtual interface has been created without MAC address
- But the network card has one, so the interface is looked for using it
- The network interface is not found, so it's created
- An error is risen because an interface with the same name already
  exists

This patch sets the MAC address on the interface if it exists, no matter if it is virtual or not.