### PR TITLE
fix(#212): prevent server tags to be override by default

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -45,6 +45,7 @@ def get_config():
                    help="Command to output hostname, used as Device's name in netbox")
     p.add_argument('--device.tags', default=r'',
                    help='tags to use for a host')
+    p.add_argument('--preserve-tags', action='store_true', help='Append new unique tags, preserve those already present')
     p.add_argument('--device.custom_fields', default=r'',
                    help='custom_fields to use for a host, eg: field1=v1,field2=v2')
     p.add_argument('--device.blade_role', default=r'Blade',

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -444,8 +444,15 @@ class ServerBase():
             server.name = self.get_hostname()
             update += 1
 
-        if sorted(set([x.name for x in server.tags])) != sorted(set(self.tags)):
-            server.tags = [x.id for x in self.nb_tags]
+        server_tags = sorted(set([x.name for x in server.tags]))
+        tags = sorted(set(self.tags))
+        if server_tags != tags:
+            new_tags_ids = [x.id for x in self.nb_tags]
+            if not config.preserve_tags:
+                server.tags = new_tags_ids
+            else:
+                server_tags_ids = [x.id for x in server.tags]
+                server.tags = sorted(set(new_tags_ids + server_tags_ids))
             update += 1
 
         if server.custom_fields != self.custom_fields:


### PR DESCRIPTION
Add a param `--preserve-tags` to keep all tags, default behavior is to override tags.