### PR TITLE
Bug: if HP raidcard have no discs

### DIFF
--- a/netbox_agent/raid/hp.py
+++ b/netbox_agent/raid/hp.py
@@ -10,7 +10,6 @@ REGEXP_CONTROLLER_HP = re.compile(r'Smart Array ([a-zA-Z0-9- ]+) in Slot ([0-9]+
 class HPRaidControllerError(Exception):
     pass
 
-
 def ssacli(sub_command):
     command = ["ssacli"]
     command.extend(sub_command.split())
@@ -21,15 +20,18 @@ def ssacli(sub_command):
     )
     p.wait()
     stdout = p.stdout.read().decode("utf-8")
-    if p.returncode != 0:
+    if p.returncode == 1 and stdout.find('does not have any physical') == -1:
         mesg = "Failed to execute command '{}':\n{}".format(
             " ".join(command), stdout
         )
         raise HPRaidControllerError(mesg)
-    lines = stdout.split('\n')
-    lines = list(filter(None, lines))
+    else:
+        if stdout.find('does not have any physical') != -1:
+            return list()
+        else:
+            lines = stdout.split('\n')
+            lines = list(filter(None, lines))
     return lines
-
 
 def _parse_ctrl_output(lines):
     controllers = {}


### PR DESCRIPTION
We have a box with multiple raidcards and we still dont use the second, thats how we found this "bug" 