### PR TITLE
Fix KeyError: 'pvid' in lldp.py

### DIFF
--- a/netbox_agent/lldp.py
+++ b/netbox_agent/lldp.py
@@ -38,7 +38,7 @@ class LLDP():
                     vid = value
                     vlans[interface][value] = vlans[interface].get(vid, {})
                 elif path.endswith('vlan'):
-                    vid = value.replace('vlan-', '')
+                    vid = value.replace('vlan-', '').replace('VLAN', '')
                     vlans[interface][vid] = vlans[interface].get(vid, {})
                 elif 'pvid' in path:
                     vlans[interface][vid]['pvid'] = True

--- a/tests/fixtures/lldp/223.txt
+++ b/tests/fixtures/lldp/223.txt
@@ -1,0 +1,7 @@
+lldp.eth0.vlan.vlan-id=300
+lldp.eth0.vlan.pvid=yes
+lldp.eth0.vlan=VLAN300
+
+# PVID is optional
+lldp.eth1.vlan.vlan-id=300
+lldp.eth1.vlan=VLAN300

--- a/tests/network.py
+++ b/tests/network.py
@@ -18,3 +18,13 @@ def test_lldp_parse_with_port_desc(fixture):
 def test_lldp_parse_without_ifname(fixture):
     lldp = LLDP(fixture)
     assert lldp.get_switch_port('eth0') == 'xe-0/0/1'
+
+
+@parametrize_with_fixtures(
+    'lldp/', only_filenames=[
+        '223.txt',
+    ])
+def test_lldp_parse_with_vlan(fixture):
+    lldp = LLDP(fixture)
+    assert lldp.get_switch_vlan('eth0') == {'300': {'pvid': True}}
+    assert lldp.get_switch_vlan('eth1') == {'300': {}}


### PR DESCRIPTION
```
lldp.eth0.vlan.vlan-id=300
lldp.eth0.vlan.pvid=yes
lldp.eth0.vlan=VLAN300
```
```
Version: lldpd 1.0.11
```

```
Traceback (most recent call last):
  File "/root/.local/bin/netbox_agent", line 8, in <module>
    sys.exit(main())
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/cli.py", line 44, in main
    return run(config)
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/cli.py", line 39, in run
    server.netbox_create_or_update(config)
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/server.py", line 292, in netbox_create_or_update
    self.network.create_or_update_netbox_network_cards()
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/network.py", line 417, in create_or_update_netbox_network_cards
    ret, interface = self.reset_vlan_on_interface(nic, interface)
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/network.py", line 234, in reset_vlan_on_interface
    pvid_vlan = [key for (key, value) in lldp_vlan.items() if value['pvid']]
  File "/root/.local/lib/python3.10/site-packages/netbox_agent/network.py", line 234, in <listcomp>
    pvid_vlan = [key for (key, value) in lldp_vlan.items() if value['pvid']]
KeyError: 'pvid'
```
```
lldp_vlan := {'300': {'pvid': True}, 'VLAN300': {}}
```