### PR TITLE
fix: HP inventory crash is some warnings

### DIFF
--- a/netbox_agent/raid/hp.py
+++ b/netbox_agent/raid/hp.py
@@ -63,6 +63,8 @@ def _parse_pd_output(lines):
         line = line.strip()
         if not line or line.startswith('Note:'):
             continue
+        if 'cache' in line or 'reboot' in line:
+            continue
         # Parses the Array the drives are in
         if line.startswith('Array'):
             current_array = line.split(None, 1)[1]


### PR DESCRIPTION
```
DEBUG:urllib3.connectionpool:https://netbox.local:443 "GET /api/dcim/inventory-items/?device_id=9&tag=hw-disk&limit=0 HTTP/1.1" 200 52
('A cache backup failure has occurred. Please execute the "reenablecache" '
 'command')
Traceback (most recent call last):
  File "/usr/bin/netbox_agent", line 33, in <module>
    sys.exit(load_entry_point('netbox-agent==0.7.1', 'console_scripts', 'netbox_agent')())
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 50, in main
    return run(config)
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/cli.py", line 43, in run
    server.netbox_create_or_update(config)
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/server.py", line 417, in netbox_create_or_update
    self.inventory.create_or_update()
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 547, in create_or_update
    self.do_netbox_disks()
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 417, in do_netbox_disks
    disks = self.get_hw_disks()
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 332, in get_hw_disks
    for raid_card in self.get_raid_cards(filter_cards=True):
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/inventory.py", line 242, in get_raid_cards
    self.raid = raid_class()
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/raid/hp.py", line 180, in __init__
    self.convert_to_dict()
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/raid/hp.py", line 185, in convert_to_dict
    controllers = _parse_ctrl_output(lines)
  File "/opt/netbox-agent/lib/python3.6/site-packages/netbox_agent/raid/hp.py", line 34, in _parse_ctrl_output
    attr, val = line.split(': ', 1)
```

