### PR TITLE
fix: hp controller inventory, add space in ignore_patterns

### DIFF
--- a/netbox_agent/raid/hp.py
+++ b/netbox_agent/raid/hp.py
@@ -34,7 +34,7 @@ def ssacli(sub_command):
     return lines
 
 def _test_if_valid_line(line):
-    ignore_patterns = ['Note:', 'Error:', 'is not loaded', 'README', 'failure', 'cache']
+    ignore_patterns = ['Note:', 'Error:', 'is not loaded', 'README', ' failure', ' cache']
     for pattern in ignore_patterns:
         if not line or pattern in line:
             return None


### PR DESCRIPTION
to prevent false positive like `/data/cache/temp` for eg