### PR TITLE
Make IPMI information gathering optional

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -78,6 +78,7 @@ def get_config():
                    help='Regex to ignore interfaces')
     p.add_argument('--network.ignore_ips', default=r'^(127\.0\.0\..*|fe80.*|::1.*)',
                    help='Regex to ignore IPs')
+    p.add_argument('--network.ipmi', default=True, help='Enable gathering IPMI information')
     p.add_argument('--network.lldp', help='Enable auto-cabling feature through LLDP infos')
     p.add_argument('--inventory', action='store_true',
                    help='Enable HW inventory (CPU, Memory, RAID Cards, Disks) feature')

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -496,9 +496,12 @@ class Network(object):
 class ServerNetwork(Network):
     def __init__(self, server, *args, **kwargs):
         super(ServerNetwork, self).__init__(server, args, kwargs)
-        self.ipmi = self.get_ipmi()
+
+        if config.network.ipmi:
+            self.ipmi = self.get_ipmi()
         if self.ipmi:
             self.nics.append(self.ipmi)
+
         self.server = server
         self.device = self.server.get_netbox_server()
         self.nb_net = nb.dcim


### PR DESCRIPTION
This PR makes IPMI interface creation optional, for scenarios where the `ipmi lan print` command doesn't return correct information.