### PR TITLE
fix lldp.py

### DIFF
--- a/netbox_agent/lldp.py
+++ b/netbox_agent/lldp.py
@@ -31,8 +31,9 @@ class LLDP():
                 vlans[interface] = {}
 
             for path_component in path_components:
-                current_dict[path_component] = current_dict.get(path_component, {})
-                current_dict = current_dict[path_component]
+                if not isinstance(current_dict.get(path_component), dict):
+                    current_dict[path_component] = {}
+                current_dict = current_dict.get(path_component)
                 if 'vlan-id' in path:
                     vid = value
                     vlans[interface][value] = vlans[interface].get(vid, {})


### PR DESCRIPTION
It's fix for issue https://github.com/Solvik/netbox-agent/issues/274

### Issue
There might be an issue when the path_component is already a string in the dictionary.
When this happens, current_dict becomes a string, and then current_dict[final] = value, it throws the TypeError.


### Expected behavior
current_dict should always be dict, and not failed

### Environment:
OS: [e.g. Rocky 8 18.04]
Netbox agent version [v0.7.2]
