### PR TITLE
mandatory role and python 3.6

### DIFF
--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -204,6 +204,7 @@ class ServerBase():
             tenant=tenant.id if tenant else None,
             rack=rack.id if rack else None,
             tags=[{'name': x} for x in self.tags],
+            role=device_type.id,
             custom_fields=self.custom_fields,
         )
         return new_chassis
@@ -226,6 +227,7 @@ class ServerBase():
             site=datacenter.id if datacenter else None,
             tenant=tenant.id if tenant else None,
             rack=rack.id if rack else None,
+            role=device_role.id,
             tags=[{'name': x} for x in self.tags],
             custom_fields=self.custom_fields,
         )
@@ -249,6 +251,7 @@ class ServerBase():
             site=datacenter.id if datacenter else None,
             tenant=tenant.id if tenant else None,
             rack=rack.id if rack else None,
+            role=device_role.id,
             tags=[{'name': x} for x in self.tags],
         )
         return new_blade
@@ -278,6 +281,7 @@ class ServerBase():
             site=datacenter.id if datacenter else None,
             tenant=tenant.id if tenant else None,
             rack=rack.id if rack else None,
+            role=device_role.id,
             tags=[{'name': x} for x in self.tags],
         )
         return new_server

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ netaddr==0.8.0
 netifaces==0.11.0
 pyyaml==6.0.1
 jsonargparse==3.11.2
-python-slugify==8.0.1
-packaging==23.1
+python-slugify==6.1.2
+packaging==21.3
 distro==1.8.0


### PR DESCRIPTION
That PR:
- returns support of Python 3.6 shipped with RHEL 7
- adds role to create device methods 