### PR TITLE
Replaced deprecated module pkg_resources

### DIFF
--- a/netbox_agent/__init__.py
+++ b/netbox_agent/__init__.py
@@ -1,6 +1,6 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version as _get_version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = _get_version(__name__)
+except PackageNotFoundError:
     pass


### PR DESCRIPTION
Removed in Python 3.12. Use importlib instead