### PR TITLE
Workaround for Supermicro default serial number

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -28,6 +28,8 @@ def get_config():
     p.add_argument('--update-inventory', action='store_true', help='Update inventory')
     p.add_argument('--update-location', action='store_true', help='Update location')
     p.add_argument('--update-psu', action='store_true', help='Update PSU')
+    p.add_argument('--update-old-devices', action='store_true',
+                   help='Update serial number of existing (old ?) devices having same name but different serial')
     p.add_argument('--purge-old-devices', action='store_true',
                    help='Purge existing (old ?) devices having same name but different serial')
     p.add_argument('--expansion-as-device', action='store_true',

--- a/netbox_agent/vendors/supermicro.py
+++ b/netbox_agent/vendors/supermicro.py
@@ -46,9 +46,13 @@ class SupermicroHost(ServerBase):
         return None
 
     def get_service_tag(self):
-        if self.is_blade():
-            return self.baseboard[0]['Serial Number'].strip()
-        return self.system[0]['Serial Number'].strip()
+        default_serial = "0123456789"
+        baseboard_serial = self.baseboard[0]['Serial Number'].strip()
+        system_serial = str(self.system[0]['Serial Number']).strip()
+
+        if self.is_blade() or system_serial == default_serial:
+            return baseboard_serial
+        return system_serial
 
     def get_product_name(self):
         if self.is_blade():

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_requirements():
 
 setup(
     name='netbox_agent',
-    version='1.0.0',
+    version='1.0.1-rc1',
     description='NetBox agent for server',
     long_description=open('README.md', encoding="utf-8").read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Workaround for Supermicro default serial number

Solution provided by Simon Brandstetter (@Garfunkl).
See details of the problem and solution in: https://github.com/Solvik/netbox-agent/issues/296

### New command line option --update-old-devices to update the serial number of old servers

Add an alternative method to resolve server serial number and name
conflicts which updates the serial number of the existing server object
in Netbox with the same name as the current server.
    
This option addresses the situation as --purge-old-devices but does
not delete the existing server object in Netbox.
    
This option is useful if a server is replaced by another with the same
name and it is desired to keep all its properties that have been added
manually in Netbox, so the existing server object will be updated with
the serial number of the new server.

### Bump version to 1.0.1-rc1

The version was bumped only to be able to upgrade from the current version to my test version.
```
pip3 install "netbox-agent @ git+https://github.com/TiagoTT/netbox-agent@master"
```