### PR TITLE
New command line option --update-old-devices to update the serial number of old servers

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -28,6 +28,8 @@ def get_config():
     p.add_argument('--update-inventory', action='store_true', help='Update inventory')
     p.add_argument('--update-location', action='store_true', help='Update location')
     p.add_argument('--update-psu', action='store_true', help='Update PSU')
+    p.add_argument('--update-old-devices', action='store_true',
+                   help='Update serial number of existing (old ?) devices having same name but different serial')
     p.add_argument('--purge-old-devices', action='store_true',
                    help='Purge existing (old ?) devices having same name but different serial')
     p.add_argument('--expansion-as-device', action='store_true',


### PR DESCRIPTION
Add an alternative method to resolve server serial number and name conflicts which updates the serial number of the existing server object in Netbox with the same name as the current server.

This option addresses the situation as --purge-old-devices but does not delete the existing server object in Netbox.

This option is useful if a server is replaced by another with the same name and it is desired to keep all its properties that have been added manually in Netbox, so the existing server object will be updated with the serial number of the new server.