### PR TITLE
Support MAC address update of network interfaces

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -146,13 +146,7 @@ class Network(object):
         return self.nics
 
     def get_netbox_network_card(self, nic):
-        if nic["mac"] is None:
-            interface = self.nb_net.interfaces.get(name=nic["name"], **self.custom_arg_id)
-        else:
-            interface = self.nb_net.interfaces.get(
-                mac_address=nic["mac"], name=nic["name"], **self.custom_arg_id
-            )
-        return interface
+        return self.nb_net.interfaces.get(name=nic["name"], **self.custom_arg_id)
 
     def get_netbox_network_cards(self):
         return self.nb_net.interfaces.filter(**self.custom_arg_id)
@@ -463,17 +457,17 @@ class Network(object):
                 interface = self.create_netbox_nic(nic)
 
             nic_update = 0
-            if nic["name"] != interface.name:
-                logging.info(
-                    "Updating interface {interface} name to: {name}".format(
-                        interface=interface, name=nic["name"]
-                    )
-                )
-                interface.name = nic["name"]
-                nic_update += 1
-
             ret, interface = self.reset_vlan_on_interface(nic, interface)
             nic_update += ret
+
+            if nic["mac"].lower() != getattr(interface, "mac_address", "").lower():
+                logging.info(
+                    "Updating interface {interface} mac to: {mac}".format(
+                        interface=interface, mac=nic["mac"]
+                    )
+                )
+                interface.mac_address = nic["mac"]
+                nic_update += 1
 
             if hasattr(interface, "mtu"):
                 if nic["mtu"] != interface.mtu:


### PR DESCRIPTION
Always find the Netbox Interface objects by name and not by MAC address.

Drop the support to change interface name, as the interface is found by name. Add support to change the interface MAC address if missing or different from the one detected.

See: https://github.com/Solvik/netbox-agent/issues/166