### PR TITLE
Get ruff version from pyproject for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install $(grep -Po '(?<=")ruff[^"]+' pyproject.toml)
       - name: Ruff linter
         run: ruff check
   ruff_formatter:
@@ -53,6 +53,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install $(grep -Po '(?<=")ruff[^"]+' pyproject.toml)
       - name: Ruff formatter
         run: ruff format --diff


### PR DESCRIPTION
Avoids unexpected CI failures when a new ruff version is released