### PR TITLE
Use permanent MAC address as serial number on inventory network interfaces

### DIFF
--- a/netbox_agent/ethtool.py
+++ b/netbox_agent/ethtool.py
@@ -70,9 +70,18 @@ class Ethtool:
                 return {"form_factor": r.groups()[0]}
         return {}
 
+    def _parse_ethtool_permanent_address_output(self):
+        status, output = subprocess.getstatusoutput("ethtool -P {}".format(self.interface))
+        if status == 0:
+            prefix = "Permanent address: "
+            if output.startswith(prefix):
+                return {"mac": output.removeprefix(prefix).strip()}
+        return {}
+
     def parse(self):
         if which("ethtool") is None:
             return None
         output = self._parse_ethtool_output()
         output.update(self._parse_ethtool_module_output())
+        output.update(self._parse_ethtool_permanent_address_output())
         return output


### PR DESCRIPTION
Extend the Ethtool class to also gather the permanent address of the network interfaces.

Link the Inventory Items for network interface cards with the Interface Component.

Update the Inventory Items for network interface cards.