### PR TITLE
Network interface improvements

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -124,7 +124,7 @@ def get_config():
         "--network.nic_id",
         choices=("name", "mac"),
         default="name",
-        help="What property to use as NIC identifier. Always fallback to name if choice is not available",
+        help="What property to use as NIC identifier",
     )
     p.add_argument(
         "--network.primary_mac",

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -121,6 +121,12 @@ def get_config():
     p.add_argument("--network.ipmi", default=True, help="Enable gathering IPMI information")
     p.add_argument("--network.lldp", help="Enable auto-cabling feature through LLDP infos")
     p.add_argument(
+        "--network.nic_id",
+        choices=("name", "mac"),
+        default="name",
+        help="What property to use as NIC identifier. Always fallback to name if choice is not available",
+    )
+    p.add_argument(
         "--network.primary_mac",
         choices=("permanent", "temp"),
         default="temp",

--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -121,6 +121,12 @@ def get_config():
     p.add_argument("--network.ipmi", default=True, help="Enable gathering IPMI information")
     p.add_argument("--network.lldp", help="Enable auto-cabling feature through LLDP infos")
     p.add_argument(
+        "--network.primary_mac",
+        choices=("permanent", "temp"),
+        default="temp",
+        help="Which MAC address to use as primary. Permanent requires ethtool and fallbacks to temporary",
+    )
+    p.add_argument(
         "--inventory",
         action="store_true",
         help="Enable HW inventory (CPU, Memory, RAID Cards, Disks) feature",

--- a/netbox_agent/ethtool.py
+++ b/netbox_agent/ethtool.py
@@ -56,12 +56,14 @@ class Ethtool:
                 field = line[:r].strip()
                 if field not in field_map:
                     continue
-                field = field_map[field]
+                field_key = field_map[field]
                 output = line[r + 1 :].strip()
-                fields[field] = output
+                fields[field_key] = output
             else:
                 if len(field) > 0 and field in field_map:
-                    fields[field] += " " + line.strip()
+                    field_key = field_map[field]
+                    fields[field_key] += " " + line.strip()
+
         return fields
 
     def _parse_ethtool_module_output(self):

--- a/netbox_agent/ipmi.py
+++ b/netbox_agent/ipmi.py
@@ -57,6 +57,8 @@ class IPMI:
         ret["bonding"] = False
         try:
             ret["mac"] = _ipmi["MAC Address"]
+            if ret["mac"]:
+                ret["mac"] = ret["mac"].upper()
             ret["vlan"] = (
                 int(_ipmi["802.1q VLAN ID"]) if _ipmi["802.1q VLAN ID"] != "Disabled" else None
             )

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -391,13 +391,12 @@ class Network(object):
                 netbox_ip = nb.ipam.ip_addresses.create(**query_params)
             return netbox_ip
         else:
-            ip_interface = getattr(netbox_ip, "interface", None)
             assigned_object = getattr(netbox_ip, "assigned_object", None)
-            if not ip_interface or not assigned_object:
+            if not assigned_object:
                 logging.info(
                     "Assigning existing IP {ip} to {interface}".format(ip=ip, interface=interface)
                 )
-            elif (ip_interface and ip_interface.id != interface.id) or (
+            elif (
                 assigned_object and assigned_object.id != interface.id
             ):
                 old_interface = getattr(netbox_ip, "assigned_object", "n/a")

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -184,16 +184,20 @@ class Network(object):
         if nic.get("ethtool") is None:
             return self.dcim_choices["interface:type"]["Other"]
 
-        if nic["ethtool"]["speed"] == "10000Mb/s":
+        max_speed = nic["ethtool"]["max_speed"]
+        if max_speed == "-":
+            max_speed = nic["ethtool"]["speed"]
+
+        if max_speed == "10000Mb/s":
             if nic["ethtool"]["port"] in ("FIBRE", "Direct Attach Copper"):
                 return self.dcim_choices["interface:type"]["SFP+ (10GE)"]
             return self.dcim_choices["interface:type"]["10GBASE-T (10GE)"]
 
-        elif nic["ethtool"]["speed"] == "25000Mb/s":
+        elif max_speed == "25000Mb/s":
             if nic["ethtool"]["port"] in ("FIBRE", "Direct Attach Copper"):
                 return self.dcim_choices["interface:type"]["SFP28 (25GE)"]
 
-        elif nic["ethtool"]["speed"] == "1000Mb/s":
+        elif max_speed == "1000Mb/s":
             if nic["ethtool"]["port"] in ("FIBRE", "Direct Attach Copper"):
                 return self.dcim_choices["interface:type"]["SFP (1GE)"]
             return self.dcim_choices["interface:type"]["1000BASE-T (1GE)"]

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -300,6 +300,9 @@ class Network(object):
         if nic["mtu"]:
             params["mtu"] = nic["mtu"]
 
+        if nic["ethtool"] and nic["ethtool"].get("link") == "no":
+            params["enabled"] = False
+
         interface = self.nb_net.interfaces.create(**params)
 
         if nic["vlan"]:

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -555,7 +555,7 @@ class Network(object):
                     interface.mtu = nic["mtu"]
                     nic_update += 1
 
-            if nic["ethtool"]:
+            if nic.get("ethtool"):
                 if (
                     nic["ethtool"]["duplex"] != "-"
                     and interface.duplex != nic["ethtool"]["duplex"].lower()

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -489,6 +489,15 @@ class Network(object):
                 interface.name = nic["name"]
                 nic_update += 1
 
+            if nic["mac"] != interface.mac_address:
+                logging.info(
+                    "Updating interface {interface} mac to: {mac}".format(
+                        interface=interface, mac=nic["mac"]
+                    )
+                )
+                interface.mac = nic["mac"]
+                nic_update += 1
+
             ret, interface = self.reset_vlan_on_interface(nic, interface)
             nic_update += ret
 

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -482,6 +482,10 @@ class Network(object):
                 interface = self.create_netbox_nic(nic)
 
             nic_update = 0
+
+            ret, interface = self.reset_vlan_on_interface(nic, interface)
+            nic_update += ret
+
             if nic["name"] != interface.name:
                 logging.info(
                     "Updating interface {interface} name to: {name}".format(
@@ -499,9 +503,6 @@ class Network(object):
                 )
                 interface.mac = nic["mac"]
                 nic_update += 1
-
-            ret, interface = self.reset_vlan_on_interface(nic, interface)
-            nic_update += ret
 
             if hasattr(interface, "mtu"):
                 if nic["mtu"] != interface.mtu:

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -435,10 +435,14 @@ class Network(object):
     def _nic_identifier(self, nic):
         if isinstance(nic, dict):
             if config.network.nic_id == "mac":
+                if not nic["mac"]:
+                    logging.warning("MAC not available while trying to use it as the NIC identifier")
                 return nic["mac"]
             return nic["name"]
         else:
             if config.network.nic_id == "mac":
+                if not nic.mac_address:
+                    logging.warning("MAC not available while trying to use it as the NIC identifier")
                 return nic.mac_address
             return nic.name
 

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -90,7 +90,11 @@ class Network(object):
                 ip_addr.append(addr)
 
             ethtool = Ethtool(interface).parse()
-            if config.network.primary_mac == "permanent" and ethtool and ethtool.get("mac_address"):
+            if (
+                config.network.primary_mac == "permanent"
+                and ethtool
+                and ethtool.get("mac_address")
+            ):
                 mac = ethtool["mac_address"]
             else:
                 mac = open("/sys/class/net/{}/address".format(interface), "r").read().strip()
@@ -287,7 +291,13 @@ class Network(object):
         for mac in macs:
             if mac not in {nb_mac.mac_address for nb_mac in nb_macs}:
                 logging.debug("Adding MAC {mac} to {nic}".format(mac=mac, nic=nic))
-                self.nb_net.mac_addresses.create({"mac_address": mac, "assigned_object_type": "dcim.interface", "assigned_object_id": nic.id})
+                self.nb_net.mac_addresses.create(
+                    {
+                        "mac_address": mac,
+                        "assigned_object_type": "dcim.interface",
+                        "assigned_object_id": nic.id,
+                    }
+                )
 
     def create_netbox_nic(self, nic, mgmt=False):
         # TODO: add Optic Vendor, PN and Serial
@@ -410,9 +420,7 @@ class Network(object):
                 logging.info(
                     "Assigning existing IP {ip} to {interface}".format(ip=ip, interface=interface)
                 )
-            elif (
-                assigned_object and assigned_object.id != interface.id
-            ):
+            elif assigned_object.id != interface.id:
                 old_interface = getattr(netbox_ip, "assigned_object", "n/a")
                 logging.info(
                     "Detected interface change for ip {ip}: old interface is "
@@ -436,13 +444,17 @@ class Network(object):
         if isinstance(nic, dict):
             if config.network.nic_id == "mac":
                 if not nic["mac"]:
-                    logging.warning("MAC not available while trying to use it as the NIC identifier")
+                    logging.warning(
+                        "MAC not available while trying to use it as the NIC identifier"
+                    )
                 return nic["mac"]
             return nic["name"]
         else:
             if config.network.nic_id == "mac":
                 if not nic.mac_address:
-                    logging.warning("MAC not available while trying to use it as the NIC identifier")
+                    logging.warning(
+                        "MAC not available while trying to use it as the NIC identifier"
+                    )
                 return nic.mac_address
             return nic.name
 
@@ -511,7 +523,6 @@ class Network(object):
                 )
                 interface.name = nic["name"]
                 nic_update += 1
-
 
             if version.parse(nb.version) >= version.parse("4.2"):
                 # Create MAC objects

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -449,7 +449,8 @@ class Network(object):
             if config.network.nic_id == "mac":
                 if not nic["mac"]:
                     logging.warning(
-                        "MAC not available while trying to use it as the NIC identifier"
+                        "%s: MAC not available while trying to use it as the NIC identifier",
+                        nic["name"],
                     )
                 return nic["mac"]
             return nic["name"]
@@ -457,7 +458,8 @@ class Network(object):
             if config.network.nic_id == "mac":
                 if not nic.mac_address:
                     logging.warning(
-                        "MAC not available while trying to use it as the NIC identifier"
+                        "%s: MAC not available while trying to use it as the NIC identifier",
+                        nic.name,
                     )
                 return nic.mac_address
             return nic.name

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -549,6 +549,22 @@ class Network(object):
                     interface.mtu = nic["mtu"]
                     nic_update += 1
 
+            if nic["ethtool"]:
+                if (
+                    nic["ethtool"]["duplex"] != "-"
+                    and interface.duplex != nic["ethtool"]["duplex"].lower()
+                ):
+                    interface.duplex = nic["ethtool"]["duplex"].lower()
+                    nic_update += 1
+
+                if nic["ethtool"]["speed"] != "-":
+                    speed = int(
+                        nic["ethtool"]["speed"].replace("Mb/s", "000").replace("Gb/s", "000000")
+                    )
+                    if speed != interface.speed:
+                        interface.speed = speed
+                        nic_update += 1
+
             if hasattr(interface, "type"):
                 _type = self.get_netbox_type_for_nic(nic)
                 if not interface.type or _type != interface.type.value:

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -95,6 +95,8 @@ class Network(object):
                 mac = open("/sys/class/net/{}/address".format(interface), "r").read().strip()
                 if mac == "00:00:00:00:00:00":
                     mac = None
+            if mac:
+                mac = mac.upper()
 
             mtu = int(open("/sys/class/net/{}/mtu".format(interface), "r").read().strip())
             vlan = None


### PR DESCRIPTION
- Add 2 new options (defaults unchanged):
  - primary MAC: use either the permanent or temporary MAC address
  - network identifier: currently netbox-agent lookups NICs by their name + MAC (if available) to know which API object to update. This means you can't update either of these fields and lose metadata if one of these fields changes. Now it is configurable to be either device name or MAC (using the primary MAC from previous option)

New features:
- Update MAC address, if it is not used as the device identifier (Fix #166)
- Update interface name, if it is not used as the device identifier
- Netbox 4.2 compatibility (multiple / primary MAC address). Currently only one MAC will be set but we will expand this in the future
- Disable NICs if their link is known to be down
- Set speed & duplex mode

Fixed
- MAC and name changes were lost
- MAC comparison must use upper case
- IP was reassigned to interface on every run
- Virtual devices (except for tap/tun and LAGs) were tagged as Other
- Ethernet type speed (eg. 1000base-T) used the current speed instead of the max speed supported