### PR TITLE
Add support for 2.5GBASE-T and 5GBASE-T interface types

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -197,6 +197,12 @@ class Network(object):
             if nic["ethtool"]["port"] in ("FIBRE", "Direct Attach Copper"):
                 return self.dcim_choices["interface:type"]["SFP28 (25GE)"]
 
+        elif max_speed == "5000Mb/s":
+            return self.dcim_choices["interface:type"]["5GBASE-T (5GE)"]
+
+        elif max_speed == "2500Mb/s":
+            return self.dcim_choices["interface:type"]["2.5GBASE-T (2.5GE)"]
+
         elif max_speed == "1000Mb/s":
             if nic["ethtool"]["port"] in ("FIBRE", "Direct Attach Copper"):
                 return self.dcim_choices["interface:type"]["SFP (1GE)"]


### PR DESCRIPTION
These max_speed of 2500Mbps and 5000Mbps are BaseT only as far as I can tell so I didn't bother to check the port type, but I can add that in if desired

There are 2.5GBase-SR SFP transceivers (not sure if these are part of any kind of standard) but that doesn't seem to be an option in netbox and SFP ports even when capable of 2.5G get reported as max_speed 1000Mbps as far as I can tell