### PR TITLE
Avoid long inventory names, and account for lldp information not containing "iface" or "descr"

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -90,6 +90,7 @@ def get_config():
         "--device.chassis_role", default=r"Server Chassis", help="role to use for a chassis"
     )
     p.add_argument("--device.server_role", default=r"Server", help="role to use for a server")
+    p.add_argument("--device.autocreate_device_type", default=True, help="Define whether a device type should be create when it doesnt exist.")
     p.add_argument("--tenant.driver", help="tenant driver, ie cmd, file")
     p.add_argument("--tenant.driver_file", help="tenant driver custom driver file path")
     p.add_argument("--tenant.regex", help="tenant regex to extract Netbox tenant slug")

--- a/netbox_agent/inventory.py
+++ b/netbox_agent/inventory.py
@@ -159,12 +159,14 @@ class Inventory:
 
     def create_netbox_interface(self, iface):
         manufacturer = self.find_or_create_manufacturer(iface["vendor"])
+        # Netbox name character limit is 64 characters
+        char_limit = 64
         _ = nb.dcim.inventory_items.create(
             device=self.device_id,
             manufacturer=manufacturer.id,
             discovered=True,
             tags=[{"name": INVENTORY_TAG["interface"]["name"]}],
-            name="{}".format(iface["product"]),
+            name="{}".format((iface["product"][:char_limit-3] + '..') if (len(iface["product"]) > char_limit) else iface["product"]),
             serial="{}".format(iface["serial"]),
             description="{} {}".format(iface["description"], iface["name"]),
         )

--- a/netbox_agent/lldp.py
+++ b/netbox_agent/lldp.py
@@ -62,7 +62,12 @@ class LLDP:
             return None
         if self.data["lldp"][interface]["port"].get("ifname"):
             return self.data["lldp"][interface]["port"]["ifname"]
-        return self.data["lldp"][interface]["port"]["descr"]
+        if self.data["lldp"][interface]["port"].get("local"):
+            return self.data["lldp"][interface]["port"]["local"]
+        if self.data["lldp"][interface]["port"].get("descr"):  
+            return self.data["lldp"][interface]["port"]["descr"]
+        return None
+
 
     def get_switch_vlan(self, interface):
         # lldp.eth0.vlan.vlan-id=296

--- a/netbox_agent/misc.py
+++ b/netbox_agent/misc.py
@@ -1,9 +1,11 @@
 from contextlib import suppress
+from netbox_agent.config import config
 from netbox_agent.config import netbox_instance as nb
 from slugify import slugify
 from shutil import which
 import distro
 import subprocess
+import logging
 import socket
 import re
 
@@ -23,7 +25,12 @@ def get_device_role(role):
 def get_device_type(type):
     device_type = nb.dcim.device_types.get(model=type)
     if device_type is None:
-        raise Exception('DeviceType "{}" does not exist, please create it'.format(type))
+        if config.device.autocreate_device_type:
+            logging.info(
+                'DeviceType "{}" does not yet exist, it will be created'.format(type)
+            )
+        else:
+            raise Exception('DeviceType "{}" does not exist, please create it, or set device.autocreate_device_type to true'.format(type))
     return device_type
 
 

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -279,7 +279,8 @@ class ServerBase:
         device_type = get_device_type(self.get_product_name())
         if not device_type:
             if config.device.autocreate_device_type:
-                
+                device_type_create = _netbox_create_device_type()
+                device_type = get_device_type(self.get_product_name())
             else:
                 raise Exception('Chassis "{}" doesn\'t exist'.format(self.get_chassis()))
         serial = self.get_service_tag()

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -293,7 +293,7 @@ class ServerBase:
         device_type = get_device_type(self.get_product_name())
         if not device_type:
             if config.device.autocreate_device_type:
-                device_type_create = _netbox_create_device_type()
+                device_type_create = self._netbox_create_device_type()
                 device_type = get_device_type(self.get_product_name())
             else:
                 raise Exception('Chassis "{}" doesn\'t exist'.format(self.get_chassis()))

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -13,11 +13,11 @@ from netbox_agent.misc import (
 from netbox_agent.network import ServerNetwork
 from netbox_agent.power import PowerSupply
 from pprint import pprint
+from slugify import slugify
 import subprocess
 import logging
 import socket
 import sys
-
 
 class ServerBase:
     def __init__(self, dmi=None):
@@ -224,9 +224,10 @@ class ServerBase:
                 model=model
             )
         )
-        new_device_type = nb.dcim.devices.create(
+        new_device_type = nb.dcim.device_types.create(
             manufacturer = nb.dcim.manufacturers.get(name=manufacturer).id,
-            model = model
+            model = model,
+            slug=slugify(model)
             )
         return new_device_type
 

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -147,6 +147,7 @@ class ServerBase:
         """
         Return the Manufacturer from dmidecode info, and create it if needed
         """
+        print(self.system[0])
         manufacturer = Inventory.find_or_create_manufacturer(self.system[0]["Manufacturer"].strip())
         return manufacturer
 

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -274,6 +274,19 @@ class ServerBase:
                 server.serial = serial
                 server.save()
 
+    def _netbox_create_device_type(self):
+        manufacturer = self.get_manufacturer()
+        model = self.get_product_name()
+        logging.info(
+            "Creating device type {model}.".format(
+                model=model
+            )
+        new_device_type = nb.dcim.devices.create(
+            manufacturer = netbox.dcim.manufacturers.get(name=manufacturer).id,
+            model = model
+            )
+        return new_device_type
+
     def _netbox_create_server(self, datacenter, tenant, rack):
         device_role = get_device_role(config.device.server_role)
         device_type = get_device_type(self.get_product_name())
@@ -302,15 +315,6 @@ class ServerBase:
             tags=[{"name": x} for x in self.tags],
         )
         return new_server
-
-    def _netbox_create_device_type(self):
-        manufacturer = self.get_manufacturer()
-        model = self.get_product_name()
-        new_device_type = nb.dcim.devices.create(
-            manufacturer = netbox.dcim.manufacturers.get(name=manufacturer).id,
-            model = model
-            )
-        return new_device_type
 
     def get_netbox_server(self, expansion=False):
         if expansion is False:

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -225,7 +225,7 @@ class ServerBase:
             )
         )
         new_device_type = nb.dcim.devices.create(
-            manufacturer = netbox.dcim.manufacturers.get(name=manufacturer).id,
+            manufacturer = nb.dcim.manufacturers.get(name=manufacturer).id,
             model = model
             )
         return new_device_type

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -281,6 +281,7 @@ class ServerBase:
             "Creating device type {model}.".format(
                 model=model
             )
+        )
         new_device_type = nb.dcim.devices.create(
             manufacturer = netbox.dcim.manufacturers.get(name=manufacturer).id,
             model = model


### PR DESCRIPTION
2 Bugs fixed in this one: 

- Netbox 4.3 does not allow inventory item names to be longer than 64 characters. Changes to inventory.py ensure that the name string is truncated if longer than 64 characters
- Certain switches (including some netgears) will store the port information under the variable "local" rather than "iface". In addition to that, I can imagine cases where "descr" does not exist, despite information being returned for the interface of interest by lldp