### PR TITLE
Move debug print before netbox_create_or_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ INFO:root:Create new IP 42.42.42.43/24 on enp1s0f1
 INFO:root:Creating Disk Samsung SSD 850 S2RBNX0K101698D
 ```
 
+## Debug Mode
+
+The `--debug` flag prints detailed information about the device before attempting to create or update it in Netbox. This is useful for troubleshooting issues or verifying what data will be sent to Netbox.
+
+```
+# netbox_agent -c /etc/netbox_agent.yaml --debug --register
+Datacenter: dc-1
+Netbox Datacenter: dc-1
+Rack: rack-01
+Netbox Rack: rack-01
+Is blade: False
+Got expansion: False
+Product Name: ProLiant DL380 Gen10
+Platform: x86-64
+Chassis: Default string
+Chassis service tag: 2M25XX0020
+Service tag: 2M25XX0020
+NIC:
+[{'name': 'eno1', 'mac': 'a8:1e:84:f2:9e:69', ...}, ...]
+INFO:root:Creating chassis blade (serial: QTFCQ574502EF)
+...
+```
+
 # Configuration
 
 ```

--- a/netbox_agent.yaml.example
+++ b/netbox_agent.yaml.example
@@ -51,3 +51,8 @@ rack_location:
 #   regex: '.*-(\d+)'
 
 inventory: true
+
+# Enable debug mode to print detailed device information
+# This is useful for troubleshooting before registration or updates
+# Same as using the --debug or -d command line flag
+# debug: true

--- a/netbox_agent/cli.py
+++ b/netbox_agent/cli.py
@@ -45,6 +45,8 @@ def run(config):
         print("netbox-agent is not compatible with Netbox prior to version 3.7")
         return 1
 
+    if config.debug:
+        server.print_debug()
     if (
         config.register
         or config.update_all
@@ -54,8 +56,6 @@ def run(config):
         or config.update_psu
     ):
         server.netbox_create_or_update(config)
-    if config.debug:
-        server.print_debug()
     return 0
 
 


### PR DESCRIPTION
## Problem

Previously, if an error occurred during `netbox_create_or_update()`, the debug information would never be printed since `print_debug()` was called **after** the update operation. This made troubleshooting failures difficult since you couldn't see the data that was being sent to Netbox.

## Solution

This PR moves the debug print to occur **before** the update attempt, ensuring debug data is visible even when errors occur. It also adds documentation for the `--debug` flag which was previously undocumented.

## Changes

- Moved `server.print_debug()` call in [cli.py](netbox_agent/cli.py) to execute before `server.netbox_create_or_update(config)`
- Added Debug Mode section to README.md with usage examples
- Added commented `debug` option to netbox_agent.yaml.example

## Testing

The change preserves all existing functionality - debug output just occurs earlier in the execution flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)