### PR TITLE
Fix --update-hypervisor flag not triggering updates

### DIFF
--- a/netbox_agent/cli.py
+++ b/netbox_agent/cli.py
@@ -52,6 +52,7 @@ def run(config):
         or config.update_location
         or config.update_inventory
         or config.update_psu
+        or config.update_hypervisor
     ):
         server.netbox_create_or_update(config)
     if config.debug:


### PR DESCRIPTION
## Problem

The `--update-hypervisor` flag was defined in [config.py](netbox_agent/config.py) and its logic was implemented in [server.py:442-443](netbox_agent/server.py#L442-L443), but it was missing from the condition in [cli.py:48-56](netbox_agent/cli.py#L48-L56) that triggers `netbox_create_or_update()`.

This meant running `netbox_agent --update-hypervisor` would do nothing because the update method was never called.

Fixes: https://github.com/Solvik/netbox-agent/issues/400

## Solution

Added `config.update_hypervisor` to the condition in cli.py so that the flag now properly triggers the hypervisor update logic.

## Changes

- Added `or config.update_hypervisor` to the condition at [cli.py:48-56](netbox_agent/cli.py#L48-L56)

## Testing

With this fix, running `netbox_agent --update-hypervisor` will now correctly call `server.netbox_create_or_update(config)`, which will trigger the hypervisor cluster and VM updates when `config.virtual.hypervisor` is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)