### PR TITLE
Fix duplicate PSU creation when dmidecode reports identical PSUs

### DIFF
--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -17,6 +17,8 @@ class PowerSupply:
 
     def get_power_supply(self):
         power_supply = []
+        seen_psus = set()
+
         for psu in dmidecode.get_by_type(self.server.dmi, PSU_DMI_TYPE):
             if "Present" not in psu["Status"] or psu["Status"] == "Not Present":
                 continue
@@ -36,6 +38,20 @@ class PowerSupply:
                 continue
             if sn == "":
                 sn = "N/A"
+
+            # Create a unique key based on all PSU attributes to detect duplicates
+            psu_key = (sn, desc, max_power)
+
+            # Skip duplicate PSUs (same serial, description, and max power)
+            if psu_key in seen_psus:
+                logging.debug(
+                    "Skipping duplicate PSU: name={}, description={}, max_power={}W".format(
+                        sn, desc, max_power
+                    )
+                )
+                continue
+
+            seen_psus.add(psu_key)
             power_supply.append(
                 {
                     "name": sn,


### PR DESCRIPTION
## Problem

Fixes #402

When dmidecode reports multiple power supplies with identical data (common with generic/placeholder values like "Default string"), the agent attempts to create duplicate power ports in Netbox. This causes a 400 error:

```
RequestError: The request failed with code 400 Bad Request: {'__all__': ['Power port with this Device and Name already exists.']}
```

**Example dmidecode output:**
```
System Power Supply
        Power Unit Group: 1
        Location: Default string
        Name: Default string
        Manufacturer: Default string
        Serial Number: Default string
        ...
(repeated 3 times identically)
```

Since all PSUs have empty serial numbers, they all get name="N/A" and identical descriptions, causing Netbox to reject the duplicates.

## Solution

Added deduplication logic in [power.py:18-64](netbox_agent/power.py#L18-L64) `get_power_supply()` method:
- Track seen PSUs using a set of tuples: `(serial_number, description, max_power)`
- Skip any PSU that matches a previously seen combination
- Log skipped duplicates at DEBUG level

## Changes

- Added `seen_psus` set to track unique PSU combinations
- Added duplicate check before appending PSU to the list
- Added debug logging for skipped duplicates

## Testing

With this fix, systems reporting multiple identical PSUs will only create one power port in Netbox instead of failing on duplicate creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)