### PR TITLE
Fix netbox-agent crashes when dmidecode returns 0w power

### DIFF
--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -25,6 +25,10 @@ class PowerSupply:
                 max_power = int(psu.get("Max Power Capacity").split()[0])
             except ValueError:
                 max_power = None
+
+            if max_power is not None and max_power < 1:
+                max_power = None
+
             desc = "{} - {}".format(
                 psu.get("Manufacturer", "No Manufacturer").strip(),
                 psu.get("Name", "No name").strip(),


### PR DESCRIPTION
Some hardware reports 0W for PSU power via dmidecode, which causes netbox-agent to send invalid values to NetBox. This change sets power values to None when they are less than 1W to prevent validation errors.