### PR TITLE
network: resolve primary_mac_address by MAC object id

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -551,7 +551,16 @@ class Network(object):
                 if version.parse(nb.version) < version.parse("4.2"):
                     interface.mac_address = nic["mac"]
                 else:
-                    interface.primary_mac_address = {"mac_address": nic["mac"]}
+                    # Resolve the MAC object scoped to THIS interface so the
+                    # lookup is unambiguous when the same MAC string exists on
+                    # multiple interfaces (e.g. vlan/vxlan stacks, bonds, ipmi).
+                    nb_mac_obj = self.nb_net.mac_addresses.get(
+                        interface_id=interface.id, mac_address=nic["mac"]
+                    )
+                    if nb_mac_obj:
+                        interface.primary_mac_address = nb_mac_obj.id
+                    else:
+                        interface.primary_mac_address = {"mac_address": nic["mac"]}
                 nic_update += 1
 
             if hasattr(interface, "mtu"):


### PR DESCRIPTION
On NetBox 4.2+ MAC addresses are first-class objects and the same MAC string can legitimately exist on multiple interfaces (VLAN/VXLAN stacks inherit the lower device's MAC, bonded slaves share the bond MAC, IPMI sometimes overlaps with a regular NIC, etc.).

Sending `primary_mac_address = {"mac_address": "<str>"}` makes NetBox resolve the FK by string, which fails as soon as more than one MAC object matches:

    400 Bad Request: {'primary_mac_address':
      ["Multiple objects match the provided attributes:
        {'mac_address': 'AE:72:10:EA:FA:60'}"]}

Resolve the MAC object scoped to the current interface (which is always unique) and assign primary_mac_address by its numeric id instead. Fall back to the previous behaviour if the object can't be found.

Fixes: #371