### PR TITLE
Quick fix VLAN detection for named interfaces

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -17,6 +17,23 @@ from netbox_agent.lldp import LLDP
 VIRTUAL_NET_FOLDER = Path("/sys/devices/virtual/net")
 
 
+def get_vlan_id(interface, vlan_root=Path("/proc/net/vlan")):
+    vlan_path = vlan_root / interface
+    try:
+        if vlan_path.is_file():
+            match = re.search(r"\bVID:\s*(\d+)\b", vlan_path.read_text())
+            if match:
+                return int(match.group(1))
+    except OSError:
+        pass
+
+    parts = interface.split(".")
+    if len(parts) > 1 and parts[1].isdigit():
+        return int(parts[1])
+
+    return None
+
+
 class Network(object):
     def __init__(self, server, *args, **kwargs):
         self.nics = []
@@ -104,9 +121,7 @@ class Network(object):
                 mac = mac.upper()
 
             mtu = int(open("/sys/class/net/{}/mtu".format(interface), "r").read().strip())
-            vlan = None
-            if len(interface.split(".")) > 1:
-                vlan = int(interface.split(".")[1])
+            vlan = get_vlan_id(interface)
 
             bonding = False
             bonding_slaves = []

--- a/tests/network.py
+++ b/tests/network.py
@@ -1,4 +1,5 @@
 from netbox_agent.lldp import LLDP
+from netbox_agent.network import get_vlan_id
 from tests.conftest import parametrize_with_fixtures
 
 
@@ -34,3 +35,25 @@ def test_lldp_parse_with_vlan(fixture):
     lldp = LLDP(fixture)
     assert lldp.get_switch_vlan("eth0") == {"300": {"pvid": True}}
     assert lldp.get_switch_vlan("eth1") == {"300": {}}
+
+
+def test_get_vlan_id_from_kernel_vlan_info(tmp_path):
+    (tmp_path / "p6p3.vlan9").write_text("p6p3.vlan9  VID: 9       REORDER_HDR: 1\n")
+    assert get_vlan_id("p6p3.vlan9", tmp_path) == 9
+
+
+def test_get_vlan_id_from_numeric_suffix(tmp_path):
+    assert get_vlan_id("eth0.9", tmp_path) == 9
+    assert get_vlan_id("eno1.50", tmp_path) == 50
+    assert get_vlan_id("eth0.9.extra", tmp_path) == 9
+
+
+def test_get_vlan_id_from_non_numeric_dotted_name(tmp_path):
+    assert get_vlan_id("foo.bar", tmp_path) is None
+
+
+def test_get_vlan_id_with_unusable_kernel_data(tmp_path):
+    (tmp_path / "eth0.9").write_text("unexpected content\n")
+    (tmp_path / "p6p3.vlan9").write_text("unexpected content\n")
+    assert get_vlan_id("eth0.9", tmp_path) == 9
+    assert get_vlan_id("p6p3.vlan9", tmp_path) is None


### PR DESCRIPTION
# PR title

Fix VLAN detection for named interfaces

# PR body

## Summary

Fix VLAN detection for interfaces whose names do not end directly in a numeric VLAN ID, for example:

```text
p6p3.vlan9
```

## Problem

The current network interface scan assumes that anything after `.` can be converted directly to an integer VLAN ID:

```python
vlan = None
if len(interface.split(".")) > 1:
    vlan = int(interface.split(".")[1])
```

This works for interface names such as `eth0.9`, but raises a `ValueError` for valid VLAN interface names such as `p6p3.vlan9`.

Linux exposes the actual VLAN ID in `/proc/net/vlan/<interface>`, for example:

```text
p6p3.vlan9  VID: 9
```

## Fix

The new VLAN detection helper:

- reads the VLAN ID from `/proc/net/vlan/<interface>` when available
- preserves existing support for numeric dotted names such as `eth0.9`
- handles names such as `p6p3.vlan9`
- returns no VLAN instead of raising an exception for unrelated dotted interface names
- falls back safely if kernel VLAN metadata is unavailable or unusable

## Tests

Added regression coverage for:

- kernel-reported VLAN IDs such as `p6p3.vlan9`
- existing numeric suffixes such as `eth0.9` and `eno1.50`
- non-numeric dotted interface names
- unusable kernel VLAN metadata

Validation completed successfully:

```text
4 VLAN regression tests passed
7 tests/network.py tests passed
ruff check passed
ruff format --check passed
```